### PR TITLE
Add options parameter to scoped_cache_key

### DIFF
--- a/lib/scoped_cache_keys.rb
+++ b/lib/scoped_cache_keys.rb
@@ -1,8 +1,8 @@
 require 'scoped_cache_keys/version'
 
 module ScopedCacheKeys
-  def scoped_cache_key(scope)
-    base_key = Rails.cache.fetch(build_scoped_cache_key([scope])){ Time.now.to_f }
+  def scoped_cache_key(scope, options = nil)
+    base_key = Rails.cache.fetch(build_scoped_cache_key([scope]), options) { Time.now.to_f }
     build_scoped_cache_key [scope, base_key]
   end
 


### PR DESCRIPTION
It is sometimes desirable to configure a scoped cache key with specific cache options, such as a `expires_in` that differs from the application-wide setting.
